### PR TITLE
feat: Setup DQN loss and training components (#6)

### DIFF
--- a/scratchpads/scratchpad-issue-6-plan.md
+++ b/scratchpads/scratchpad-issue-6-plan.md
@@ -1,0 +1,91 @@
+# Issue 6: DQN Training Components Implementation
+
+## Overview
+Implemented DQN training components using TorchRL, including loss module, exploration, replay buffer, and target network updates.
+
+## Key Implementation Details
+
+### 1. DQN Loss Module
+- Uses TorchRL's `DQNLoss` with configurable parameters
+- Supports smooth L1 and L2 loss functions
+- Includes proper gamma setting via `make_value_estimator()`
+- Enables target network usage with `delay_value=True`
+
+### 2. Q-Value Actor
+- Implemented `create_qvalue_actor()` using TorchRL's `QValueActor`
+- Directly wraps Q-network without manual TensorDictModule
+- Handles action selection based on Q-values
+- Compatible with exploration modules
+
+### 3. Exploration Module
+- Epsilon-greedy exploration with linear decay
+- Configurable start/end epsilon and decay steps
+- Works seamlessly with QValueActor
+
+### 4. Target Network Updates
+- Supports both soft and hard updates
+- Soft updates use TorchRL's eps parameter (tau equivalent)
+- Updates applied to loss module directly
+
+### 5. Replay Buffer
+- Uses `TensorDictReplayBuffer` with lazy memory mapping
+- Configurable size and batch size
+- Supports device placement and prefetching
+
+## Important Lessons Learned
+
+### Tensor Shape Requirements
+- Rewards and done/terminated flags must have shape `[1]` not `[]` when adding to replay buffer
+- This ensures proper batching: `[batch_size, 1]` instead of `[batch_size]`
+- Required for `td0_return_estimate` to compute TD targets correctly
+
+### API Differences
+- `QValueActor` requires module as first positional argument
+- TorchRL uses `eps` parameter for soft updates (not `tau`)
+- `TensorDictModule` should be imported from `tensordict.nn`
+
+## Testing Coverage
+- All components have comprehensive unit tests
+- Integration test verifies components work together
+- Tests cover custom parameters and edge cases
+- Device placement tests ensure GPU compatibility
+
+## Usage Example
+```python
+from rl_demo.models.qnet import create_qnet
+from rl_demo.trainers.dqn_components import create_dqn_training_components
+from torchrl.data import OneHot
+
+# Create Q-network
+qnet = create_qnet()
+
+# Define action space
+action_spec = OneHot(11)  # 11 discrete actions
+
+# Create all components
+components = create_dqn_training_components(
+    qnet=qnet,
+    action_spec=action_spec,
+    gamma=0.99,
+    eps_start=1.0,
+    eps_end=0.01,
+    eps_decay_steps=10000,
+    buffer_size=10000,
+    batch_size=32,
+    tau=0.995,
+)
+
+# Access components
+actor = components["actor"]
+loss_module = components["loss_module"]
+exploration = components["exploration_module"]
+replay_buffer = components["replay_buffer"]
+target_updater = components["target_updater"]
+```
+
+## Integration with Training Loop
+The components are designed to work together in a standard DQN training loop:
+1. Use `actor` with `exploration_module` for action selection during training
+2. Store transitions in `replay_buffer` with proper tensor shapes
+3. Sample batches and compute loss with `loss_module`
+4. Update target network periodically with `target_updater.step()`

--- a/src/rl_demo/trainers/dqn_components.py
+++ b/src/rl_demo/trainers/dqn_components.py
@@ -1,0 +1,279 @@
+"""DQN training components using TorchRL."""
+
+import torch
+import torch.nn as nn
+from tensordict.nn import TensorDictModule
+from torchrl.data import (
+    LazyMemmapStorage,
+    TensorDictReplayBuffer,
+)
+from torchrl.data.replay_buffers import SamplerWithoutReplacement
+from torchrl.modules import EGreedyModule, QValueActor
+from torchrl.objectives import DQNLoss, HardUpdate, SoftUpdate
+
+
+def create_dqn_loss(
+    value_network: nn.Module | QValueActor,
+    gamma: float = 0.99,
+    loss_function: str = "smooth_l1",
+    delay_value: bool = True,
+    device: torch.device | str = "cpu",
+) -> DQNLoss:
+    """Create DQN loss module with specified configuration.
+
+    Args:
+        value_network: Q-network module or QValueActor that outputs action values
+        gamma: Discount factor for future rewards (default: 0.99)
+        loss_function: Loss function to use, either "smooth_l1" or "l2" (default: "smooth_l1")
+        delay_value: Whether to use a target network (default: True)
+        device: Device to place the loss module on (default: "cpu")
+
+    Returns:
+        DQNLoss: Configured DQN loss module ready for training
+
+    Example:
+        >>> qnet = create_qnet()
+        >>> actor = QValueActor(qnet, in_keys=["observation"], spec=env.action_spec)
+        >>> loss_module = create_dqn_loss(actor)
+    """
+    loss_module = DQNLoss(
+        value_network=value_network,
+        loss_function=loss_function,
+        delay_value=delay_value,
+    )
+
+    # Set gamma using make_value_estimator
+    loss_module.make_value_estimator(gamma=gamma)
+
+    # Move to specified device
+    loss_module = loss_module.to(device)
+
+    return loss_module
+
+
+def create_exploration_module(
+    action_spec,
+    eps_start: float = 1.0,
+    eps_end: float = 0.01,
+    annealing_num_steps: int = 10000,
+) -> EGreedyModule:
+    """Create epsilon-greedy exploration module with linear decay.
+
+    Args:
+        action_spec: Action specification from the environment
+        eps_start: Initial epsilon value for exploration (default: 1.0)
+        eps_end: Final epsilon value after decay (default: 0.01)
+        annealing_num_steps: Number of steps to decay epsilon over (default: 10000)
+
+    Returns:
+        EGreedyModule: Configured epsilon-greedy exploration module
+
+    Example:
+        >>> from torchrl.data import OneHot
+        >>> action_spec = OneHot(11)  # 11 discrete actions
+        >>> exploration = create_exploration_module(action_spec)
+    """
+    exploration_module = EGreedyModule(
+        spec=action_spec,
+        eps_init=eps_start,
+        eps_end=eps_end,
+        annealing_num_steps=annealing_num_steps,
+    )
+
+    return exploration_module
+
+
+def create_target_updater(
+    loss_module: DQNLoss,
+    update_type: str = "soft",
+    tau: float = 0.995,
+) -> SoftUpdate | HardUpdate:
+    """Create target network updater for DQN.
+
+    Args:
+        loss_module: DQN loss module containing the value network
+        update_type: Type of update - "soft" or "hard" (default: "soft")
+        tau: Soft update interpolation parameter (default: 0.995)
+            For soft updates: target = tau * target + (1 - tau) * main
+            Note: TorchRL uses tau differently - closer to 1 means slower updates
+
+    Returns:
+        Target network updater module (SoftUpdate or HardUpdate)
+
+    Example:
+        >>> loss_module = create_dqn_loss(actor)
+        >>> updater = create_target_updater(loss_module)
+        >>> # In training loop:
+        >>> if step % 100 == 0:
+        ...     updater.step()
+    """
+    if update_type == "soft":
+        updater = SoftUpdate(
+            loss_module,
+            eps=tau,  # In TorchRL, eps is used instead of tau
+        )
+    elif update_type == "hard":
+        updater = HardUpdate(
+            loss_module,
+        )
+    else:
+        raise ValueError(f"Unknown update type: {update_type}. Choose 'soft' or 'hard'.")
+
+    return updater
+
+
+def create_replay_buffer(
+    buffer_size: int = 10000,
+    batch_size: int = 32,
+    device: torch.device | str = "cpu",
+    prefetch: int | None = None,
+) -> TensorDictReplayBuffer:
+    """Create replay buffer for experience storage and sampling.
+
+    Args:
+        buffer_size: Maximum number of transitions to store (default: 10000)
+        batch_size: Number of transitions to sample per batch (default: 32)
+        device: Device to store replay buffer on (default: "cpu")
+        prefetch: Number of batches to prefetch for efficiency (default: None)
+
+    Returns:
+        TensorDictReplayBuffer: Configured replay buffer ready for storing transitions
+
+    Example:
+        >>> buffer = create_replay_buffer(buffer_size=10000, batch_size=32)
+        >>> # Store transition
+        >>> buffer.add(transition_tensordict)
+        >>> # Sample batch
+        >>> batch = buffer.sample()
+    """
+    device = torch.device(device) if isinstance(device, str) else device
+
+    replay_buffer = TensorDictReplayBuffer(
+        storage=LazyMemmapStorage(
+            max_size=buffer_size,
+            device=device,
+        ),
+        sampler=SamplerWithoutReplacement(),
+        batch_size=batch_size,
+        prefetch=prefetch,
+    )
+
+    return replay_buffer
+
+
+def create_qvalue_actor(
+    qnet: nn.Module,
+    action_spec,
+    in_keys: list[str] | None = None,
+) -> QValueActor:
+    """Create Q-value actor from Q-network.
+
+    Args:
+        qnet: Q-network module that outputs Q-values
+        action_spec: Action specification from environment
+        in_keys: Input keys for the network (default: ["observation"])
+
+    Returns:
+        QValueActor: Actor that selects actions based on Q-values
+
+    Example:
+        >>> qnet = create_qnet()
+        >>> actor = create_qvalue_actor(qnet, env.action_spec)
+    """
+    if in_keys is None:
+        in_keys = ["observation"]
+
+    # Create Q-value actor directly
+    actor = QValueActor(
+        module=qnet,
+        in_keys=in_keys,
+        spec=action_spec,
+    )
+
+    return actor
+
+
+def create_dqn_training_components(
+    qnet: nn.Module,
+    action_spec,
+    gamma: float = 0.99,
+    eps_start: float = 1.0,
+    eps_end: float = 0.01,
+    eps_decay_steps: int = 10000,
+    buffer_size: int = 10000,
+    batch_size: int = 32,
+    tau: float = 0.995,
+    device: torch.device | str = "cpu",
+) -> dict:
+    """Create all DQN training components in one call.
+
+    This is a convenience function that creates all the necessary components
+    for DQN training with consistent configuration.
+
+    Args:
+        qnet: Q-network module (raw neural network)
+        action_spec: Action specification from the environment
+        gamma: Discount factor (default: 0.99)
+        eps_start: Initial exploration epsilon (default: 1.0)
+        eps_end: Final exploration epsilon (default: 0.01)
+        eps_decay_steps: Steps to decay epsilon over (default: 10000)
+        buffer_size: Replay buffer capacity (default: 10000)
+        batch_size: Batch size for training (default: 32)
+        tau: Soft update parameter for target network (default: 0.995)
+        device: Device to place components on (default: "cpu")
+
+    Returns:
+        Dictionary containing:
+            - actor: QValueActor for action selection
+            - loss_module: DQN loss module
+            - exploration_module: Epsilon-greedy exploration
+            - replay_buffer: Experience replay buffer
+            - target_updater: Target network updater
+
+    Example:
+        >>> qnet = create_qnet()
+        >>> components = create_dqn_training_components(
+        ...     qnet=qnet,
+        ...     action_spec=env.action_spec,
+        ... )
+    """
+    device = torch.device(device) if isinstance(device, str) else device
+
+    # Create Q-value actor
+    actor = create_qvalue_actor(
+        qnet=qnet.to(device),
+        action_spec=action_spec,
+        in_keys=["observation"],
+    )
+
+    # Create exploration policy
+    exploration_module = create_exploration_module(
+        action_spec=action_spec,
+        eps_start=eps_start,
+        eps_end=eps_end,
+        annealing_num_steps=eps_decay_steps,
+    )
+
+    components = {
+        "actor": actor,
+        "loss_module": create_dqn_loss(
+            value_network=actor,
+            gamma=gamma,
+            device=device,
+        ),
+        "exploration_module": exploration_module,
+        "replay_buffer": create_replay_buffer(
+            buffer_size=buffer_size,
+            batch_size=batch_size,
+            device=device,
+        ),
+    }
+
+    # Create target updater after loss module is created
+    components["target_updater"] = create_target_updater(
+        loss_module=components["loss_module"],
+        update_type="soft",
+        tau=tau,
+    )
+
+    return components

--- a/tests/test_dqn_components.py
+++ b/tests/test_dqn_components.py
@@ -1,0 +1,338 @@
+"""Tests for DQN training components."""
+
+import pytest
+import torch
+import torch.nn as nn
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+from torchrl.data import OneHot, TensorDictReplayBuffer
+from torchrl.modules import QValueActor
+from torchrl.objectives import DQNLoss, SoftUpdate
+
+from rl_demo.models.qnet import create_qnet
+from rl_demo.trainers.dqn_components import (
+    create_dqn_loss,
+    create_dqn_training_components,
+    create_exploration_module,
+    create_qvalue_actor,
+    create_replay_buffer,
+    create_target_updater,
+)
+
+
+class TestDQNLoss:
+    """Test the DQN loss module creation."""
+
+    def test_create_dqn_loss_default(self):
+        """Test DQN loss with default parameters."""
+        # Create a simple Q-network and actor
+        qnet = create_qnet()
+        action_spec = OneHot(11)
+        actor = create_qvalue_actor(qnet, action_spec)
+
+        # Create loss module
+        loss_module = create_dqn_loss(actor)
+
+        assert isinstance(loss_module, DQNLoss)
+        assert loss_module.delay_value is True
+
+    def test_create_dqn_loss_custom_params(self):
+        """Test DQN loss with custom parameters."""
+        qnet = create_qnet()
+        action_spec = OneHot(11)
+        actor = create_qvalue_actor(qnet, action_spec)
+
+        # Create loss with custom parameters
+        loss_module = create_dqn_loss(
+            value_network=actor,
+            gamma=0.95,
+            loss_function="l2",
+            delay_value=False,
+        )
+
+        assert loss_module.delay_value is False
+
+    def test_loss_computation(self):
+        """Test that loss can be computed on batch data."""
+        qnet = create_qnet()
+        action_spec = OneHot(11)
+        actor = create_qvalue_actor(qnet, action_spec)
+        loss_module = create_dqn_loss(actor)
+
+        # Create dummy batch
+        batch = TensorDict(
+            {
+                "observation": torch.randn(32, 13),
+                "action": action_spec.rand((32,)),
+                ("next", "observation"): torch.randn(32, 13),
+                ("next", "reward"): torch.randn(32, 1),
+                ("next", "done"): torch.zeros(32, 1, dtype=torch.bool),
+                ("next", "terminated"): torch.zeros(32, 1, dtype=torch.bool),
+            },
+            batch_size=[32],
+        )
+
+        # Compute loss
+        loss_vals = loss_module(batch)
+        assert "loss" in loss_vals.keys()
+        assert loss_vals["loss"].shape == ()  # Scalar loss
+
+
+class TestExplorationModule:
+    """Test epsilon-greedy exploration module."""
+
+    def test_create_exploration_default(self):
+        """Test exploration module with default parameters."""
+        action_spec = OneHot(11)
+        exploration = create_exploration_module(action_spec)
+
+        # Check initial epsilon
+        assert exploration.eps_init == 1.0
+        assert exploration.eps_end == 0.01
+        assert exploration.annealing_num_steps == 10000
+
+    def test_create_exploration_custom(self):
+        """Test exploration module with custom parameters."""
+        action_spec = OneHot(5)
+        exploration = create_exploration_module(
+            action_spec=action_spec,
+            eps_start=0.5,
+            eps_end=0.05,
+            annealing_num_steps=5000,
+        )
+
+        assert exploration.eps_init == 0.5
+        assert exploration.eps_end == 0.05
+        assert exploration.annealing_num_steps == 5000
+
+    def test_exploration_properties(self):
+        """Test exploration module properties."""
+        action_spec = OneHot(11)
+        exploration = create_exploration_module(
+            action_spec=action_spec,
+            eps_start=0.5,
+            eps_end=0.05,
+            annealing_num_steps=5000,
+        )
+
+        # Test that epsilon is set correctly
+        assert exploration.eps == 0.5
+
+
+class TestQValueActor:
+    """Test Q-value actor creation."""
+
+    def test_create_qvalue_actor(self):
+        """Test creating Q-value actor from Q-network."""
+        qnet = create_qnet()
+        action_spec = OneHot(11)
+        actor = create_qvalue_actor(qnet, action_spec)
+
+        # Check structure
+        assert isinstance(actor, QValueActor)
+
+        # Test forward pass
+        td = TensorDict({"observation": torch.randn(32, 13)}, batch_size=[32])
+        output = actor(td)
+
+        assert "action" in output.keys()
+        assert output["action"].shape == torch.Size([32, 11]) or output["action"].shape == torch.Size([32])
+
+    def test_qvalue_actor_custom_keys(self):
+        """Test Q-value actor with custom keys."""
+        qnet = create_qnet()
+        action_spec = OneHot(11)
+        actor = create_qvalue_actor(
+            qnet,
+            action_spec,
+            in_keys=["state"],
+            )
+
+        # Test with custom keys
+        td = TensorDict({"state": torch.randn(16, 13)}, batch_size=[16])
+        output = actor(td)
+
+        assert "action" in output.keys()
+        assert "action_value" in output.keys()
+
+
+class TestTargetUpdater:
+    """Test target network updater."""
+
+    def test_soft_update(self):
+        """Test soft target network updates."""
+        # Create actor and loss module
+        qnet = create_qnet()
+        action_spec = OneHot(11)
+        actor = create_qvalue_actor(qnet, action_spec)
+        loss_module = create_dqn_loss(actor)
+
+        # Create updater
+        updater = create_target_updater(
+            loss_module=loss_module,
+            update_type="soft",
+            tau=0.99,  # Slow updates
+        )
+
+        assert isinstance(updater, SoftUpdate)
+
+        # Perform update
+        updater.step()
+
+    def test_hard_update(self):
+        """Test hard target network updates."""
+        qnet = create_qnet()
+        action_spec = OneHot(11)
+        actor = create_qvalue_actor(qnet, action_spec)
+        loss_module = create_dqn_loss(actor)
+
+        updater = create_target_updater(
+            loss_module=loss_module,
+            update_type="hard",
+        )
+
+        # Perform update
+        updater.step()
+
+
+class TestReplayBuffer:
+    """Test replay buffer creation and functionality."""
+
+    def test_create_replay_buffer_default(self):
+        """Test replay buffer with default parameters."""
+        buffer = create_replay_buffer()
+
+        assert isinstance(buffer, TensorDictReplayBuffer)
+        assert buffer._batch_size == 32
+        assert len(buffer) == 0  # Empty initially
+
+    def test_create_replay_buffer_custom(self):
+        """Test replay buffer with custom parameters."""
+        buffer = create_replay_buffer(
+            buffer_size=5000,
+            batch_size=64,
+        )
+
+        assert buffer._batch_size == 64
+
+    def test_replay_buffer_operations(self):
+        """Test adding and sampling from replay buffer."""
+        buffer = create_replay_buffer(buffer_size=100, batch_size=4)
+
+        # Add some transitions
+        for i in range(10):
+            transition = TensorDict(
+                {
+                    "observation": torch.randn(13),
+                    "action": torch.tensor(i % 11),
+                    "reward": torch.tensor([float(i)]),
+                    ("next", "observation"): torch.randn(13),
+                    ("next", "done"): torch.tensor([False]),
+                },
+                batch_size=[],
+            )
+            buffer.add(transition)
+
+        assert len(buffer) == 10
+
+        # Sample a batch
+        batch = buffer.sample()
+        assert batch.batch_size[0] == 4
+        assert "observation" in batch.keys()
+        assert "action" in batch.keys()
+
+
+class TestIntegratedComponents:
+    """Test the integrated component creation function."""
+
+    def test_create_all_components(self):
+        """Test creating all DQN components at once."""
+        # Create Q-network
+        qnet = create_qnet()
+
+        # Create action spec
+        action_spec = OneHot(11)
+
+        # Create all components
+        components = create_dqn_training_components(
+            qnet=qnet,
+            action_spec=action_spec,
+        )
+
+        # Check all components exist
+        assert "actor" in components
+        assert "loss_module" in components
+        assert "exploration_module" in components
+        assert "replay_buffer" in components
+        assert "target_updater" in components
+
+        # Check types
+        assert isinstance(components["actor"], QValueActor)
+        assert isinstance(components["loss_module"], DQNLoss)
+        assert hasattr(components["exploration_module"], "eps")
+        assert hasattr(components["replay_buffer"], "sample")
+        assert hasattr(components["target_updater"], "step")
+
+    def test_components_integration(self):
+        """Test that components work together."""
+        qnet = create_qnet()
+        action_spec = OneHot(11)
+        components = create_dqn_training_components(
+            qnet=qnet,
+            action_spec=action_spec,
+            buffer_size=100,
+            batch_size=4,
+        )
+
+        # Generate some experience
+        td = TensorDict({"observation": torch.randn(13)}, batch_size=[])
+        
+        # Get action without exploration first
+        td_actor = components["actor"](td.clone())
+        assert "action" in td_actor.keys()
+        
+        # Apply exploration
+        td_explore = components["exploration_module"](td_actor)
+
+        # Add experience to buffer
+        td_explore["reward"] = torch.tensor([1.0])
+        td_explore[("next", "observation")] = torch.randn(13)
+        td_explore[("next", "done")] = torch.tensor([False])
+        td_explore[("next", "terminated")] = torch.tensor([False])
+        td_explore[("next", "reward")] = torch.tensor([0.0])
+        
+        components["replay_buffer"].add(td_explore)
+
+        # After adding enough samples, we can train
+        for i in range(10):
+            td_new = TensorDict({
+                "observation": torch.randn(13),
+                "action": torch.tensor(i % 11),
+                "reward": torch.tensor([1.0]),
+                ("next", "observation"): torch.randn(13),
+                ("next", "done"): torch.tensor([False]),
+                ("next", "terminated"): torch.tensor([False]),
+                ("next", "reward"): torch.tensor([0.0]),
+            }, batch_size=[])
+            components["replay_buffer"].add(td_new)
+
+        # Sample and compute loss
+        batch = components["replay_buffer"].sample()
+        loss_vals = components["loss_module"](batch)
+        assert "loss" in loss_vals.keys()
+
+    @pytest.mark.parametrize("device", ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"])
+    def test_device_placement(self, device):
+        """Test that components are placed on correct device."""
+        qnet = create_qnet()
+        action_spec = OneHot(11)
+
+        components = create_dqn_training_components(
+            qnet=qnet,
+            action_spec=action_spec,
+            device=device,
+        )
+
+        # Check loss module device
+        for param in components["loss_module"].parameters():
+            assert str(param.device).startswith(device)


### PR DESCRIPTION
## What & Why
- **Problem**: Need core DQN training components as specified in issue #6 to enable agent training
- **Solution**: Implemented TorchRL-based components for DQN loss, exploration, replay buffer, and target network updates

## Changes
- Added `src/rl_demo/trainers/dqn_components.py` with:
  - `create_dqn_loss()` - Configurable DQN loss module with smooth L1/L2 loss
  - `create_exploration_module()` - Epsilon-greedy exploration with linear decay
  - `create_target_updater()` - Soft/hard target network updates
  - `create_replay_buffer()` - TensorDict replay buffer with lazy storage
  - `create_qvalue_actor()` - Q-value based action selection
  - `create_dqn_training_components()` - Convenience function to create all components
- Added comprehensive test suite in `tests/test_dqn_components.py` (16 tests, all passing)
- Created documentation in `scratchpads/scratchpad-issue-6-plan.md`

## Key Implementation Details
- Uses TorchRL's `QValueActor` for proper integration
- Ensures correct tensor shapes for replay buffer (rewards/done need shape `[1]` not `[]`)
- Compatible with GPU training via device parameter
- Follows TorchRL conventions (e.g., `eps` parameter for soft updates)

## Testing
- ✅ All 16 new tests passing
- ✅ All 56 project tests passing
- ✅ Tested integration between components
- ✅ Verified tensor shape requirements for loss computation
- ✅ Device placement tests for GPU compatibility

## Review Focus
- Tensor shape handling in replay buffer transitions
- API design for component creation functions
- Integration with existing Q-network implementation

## Dependencies
- Builds on #5 (Q-network architecture) ✅ 

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)